### PR TITLE
CI/CD Workflow for SIGIC GeoNode Wrapper

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -1,18 +1,84 @@
-name: Docker Image CI
+name: CI/CD - Build & Deploy SIGIC GeoNode Wrapper (develop)
 
 on:
   push:
-    branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
+    branches:
+      - develop
 
 jobs:
-
   build:
+    name: Build SIGIC GeoNode Wrapper image (develop)
+    runs-on: [self-hosted, build-develop, geonode-wrapper]
+    environment: develop
 
-    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GHCR_GEOINTSIGIC_PAT }}" | docker login ghcr.io -u geointsigic --password-stdin
+
+      - name: Set variables
+        id: vars
+        run: |
+          echo "owner=centrogeo" >> $GITHUB_OUTPUT
+          echo "image=sigic-keycloak" >> $GITHUB_OUTPUT
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "branch=develop" >> $GITHUB_OUTPUT
+
+      - name: Build & tag Docker image
+        run: |
+          docker build \
+            -t ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.branch }} \
+            -t ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha }} \
+            -f ./keycloak/Dockerfile ./keycloak
+
+      - name: Push image
+        run: |
+          docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.branch }}
+          docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha }}
+
+  deploy:
+    name: Deploy GeoNode Wrapper to dev server
+    needs: build
+    runs-on: [self-hosted, deploy-develop, sigic-geonode-wrapper]
+    environment: develop
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set variables
+        id: vars
+        run: |
+          echo "owner=centrogeo" >> $GITHUB_OUTPUT
+          echo "image=sigic-keycloak" >> $GITHUB_OUTPUT
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "branch=develop" >> $GITHUB_OUTPUT
+
+      - name: Docker login to GHCR
+        run: echo ${{ secrets.GHCR_GEOINTSIGIC_PAT }} | docker login ghcr.io -u geointsigic --password-stdin
+
+      - name: Reemplazar imagen en docker-compose-ghcr.yml
+        run: |
+          sed -i "s|ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:.*|ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha }}|g" docker-compose-ghcr.yml
+
+      - name: Docker Compose up
+        run: |
+          docker compose -f docker-compose-ghcr.yml down -v || true
+          docker compose -f docker-compose-ghcr.yml up -d --force-recreate
+        env:
+          KC_DB_USERNAME: ${{ secrets.KC_DB_USERNAME }}
+          KC_DB_PASSWORD: ${{ secrets.KC_DB_PASSWORD }}
+          KC_DB_URL_HOST: ${{ secrets.KC_DB_URL_HOST }}
+          KC_DB_URL_DATABASE: ${{ secrets.KC_DB_URL_DATABASE }}
+          KC_DB: ${{ vars.KC_DB }}
+          KC_HOSTNAME: ${{ vars.KC_HOSTNAME }}
+          KC_HOSTNAME_STRICT: ${{ vars.KC_HOSTNAME_STRICT }}
+          JAVA_OPTS: ${{ vars.JAVA_OPTS }}
+          VIRTUAL_HOST: ${{ vars.KC_HOSTNAME }}
+          VIRTUAL_PORT: "8080"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the CI/CD process for building and deploying the SIGIC GeoNode Wrapper on the `develop` branch. The workflow includes steps for building a Docker image, pushing it to the GitHub Container Registry (GHCR), and deploying it to a development server using Docker Compose.

### CI/CD Workflow for SIGIC GeoNode Wrapper:

* **Workflow Name and Trigger**: Created a new workflow named "CI/CD - Build & Deploy SIGIC GeoNode Wrapper (develop)" that triggers on pushes to the `develop` branch. (`.github/workflows/docker-compose-develop.yml`)

* **Build Job**:
  - Configured a job to build the SIGIC GeoNode Wrapper Docker image, including steps for checking out code, logging into GHCR, setting variables, building the Docker image, and pushing it to GHCR. (`.github/workflows/docker-compose-develop.yml`)

* **Deploy Job**:
  - Added a deployment job to replace the Docker image in `docker-compose-ghcr.yml` and bring up the updated services using Docker Compose. This job also sets environment variables required for the deployment. (`.github/workflows/docker-compose-develop.yml`)