### PR TITLE
Feat/keycloak jwt

### DIFF
--- a/.github/workflows/docker-compose-develop.yml
+++ b/.github/workflows/docker-compose-develop.yml
@@ -37,6 +37,7 @@ jobs:
           echo "owner=centrogeo" >> $GITHUB_OUTPUT
           echo "geonode-image=sigic-geonode-wrapper" >> $GITHUB_OUTPUT
           echo "geoserver-image=sigic-geoserver" >> $GITHUB_OUTPUT
+          echo "nginx-image=sigic-nginx" >> $GITHUB_OUTPUT
           echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
           echo "branch=develop" >> $GITHUB_OUTPUT
 
@@ -56,6 +57,15 @@ jobs:
             -f Dockerfile .
           cd -
 
+      - name: Build & tag NGINX Docker image
+        run: |
+          cd docker/nginx
+          docker build --no-cache \
+            --build-arg BASE_IMAGE_VERSION=${{ env.NGINX_BASE_IMAGE_VERSION }} \
+            -t ghcr.io/${{ steps.vars.outputs.owner }}/sigic-nginx:${{ env.NGINX_BASE_IMAGE_VERSION }} \
+            -f Dockerfile .
+          cd -
+
       - name: Push GeoNode image
         run: |
           docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.geonode-image }}:${{ steps.vars.outputs.branch }}
@@ -64,6 +74,10 @@ jobs:
       - name: Push GeoServer image
         run: |
             docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{ steps.vars.outputs.geoserver-image }}:${{ env.GEOSERVER_BASE_IMAGE_VERSION }}
+
+      - name: Push NGINX image
+        run: |
+            docker push ghcr.io/${{ steps.vars.outputs.owner }}/${{steps.vars.outputs.nginx-image}}:${{ env.NGINX_BASE_IMAGE_VERSION }}
 
   deploy:
     name: Deploy GeoNode Wrapper to dev server

--- a/docker-compose-ghcr.yml
+++ b/docker-compose-ghcr.yml
@@ -49,7 +49,7 @@ services:
 
   # Nginx is serving django static and media files and proxies to django and geonode
   geonode:
-    image: ${COMPOSE_PROJECT_NAME}/nginx:${NGINX_BASE_IMAGE_VERSION}
+    image: ghcr.io/centrogeo/sigic-nginx:${NGINX_BASE_IMAGE_VERSION}
     build:
       context: ./docker/nginx
       dockerfile: Dockerfile

--- a/docker/nginx/geonode.conf.envsubst
+++ b/docker/nginx/geonode.conf.envsubst
@@ -52,10 +52,8 @@ location /geoserver {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-Proto $HTTP_SCHEME;
-  proxy_set_header Authorization $http_authorization;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";
-  # proxy_set_header Authorization $http_authorization;
   proxy_hide_header X-Frame-Options;
   proxy_pass http://$upstream;
   proxy_http_version 1.1;
@@ -115,6 +113,7 @@ location / {
   proxy_set_header            X-Forwarded-Host $server_name;
   proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header            X-Forwarded-Proto $HTTP_SCHEME;
+  proxy_set_header            Authorization $http_authorization if_not_empty;
   proxy_hide_header           X-Frame-Options;
   proxy_request_buffering     off;
 


### PR DESCRIPTION
This pull request adds support for building, tagging, and pushing a custom NGINX Docker image (`sigic-nginx`) to the GitHub Container Registry and updates the deployment to use this image. Additionally, there are adjustments to NGINX proxy headers to improve request handling. The most important changes are grouped below:

**CI/CD Pipeline Updates:**

* Added steps in `.github/workflows/docker-compose-develop.yml` to build, tag, and push the `sigic-nginx` Docker image, including new output variables and build arguments. [[1]](diffhunk://#diff-df0350229a00b492c0728b7dd254cd53fe8d1ee6dbe591553a8cc0aa090747e8R40) [[2]](diffhunk://#diff-df0350229a00b492c0728b7dd254cd53fe8d1ee6dbe591553a8cc0aa090747e8L54-R68) [[3]](diffhunk://#diff-df0350229a00b492c0728b7dd254cd53fe8d1ee6dbe591553a8cc0aa090747e8R78-R81)

**Deployment Configuration:**

* Updated `docker-compose-ghcr.yml` to use the `ghcr.io/centrogeo/sigic-nginx:${NGINX_BASE_IMAGE_VERSION}` image for the `geonode` service, ensuring the deployment uses the published image from the registry.

**NGINX Proxy Header Adjustments:**

* Modified `docker/nginx/geonode.conf.envsubst` to remove duplicate or unnecessary `Authorization` header forwarding in the `/geoserver` location, and conditionally set the `Authorization` header in the root location only if it is present. [[1]](diffhunk://#diff-283bc1184661326c2ea6af7a2ace059b66cd09df6b1d3e4d636603e7411142adL55-L58) [[2]](diffhunk://#diff-283bc1184661326c2ea6af7a2ace059b66cd09df6b1d3e4d636603e7411142adR116)