### PR TITLE
feat: campo general_values en Indicator y mejoras al visualizador de …

### DIFF
--- a/src/sigic_geonode/sigic_dashboard/management/commands/create_dashboard_examples.py
+++ b/src/sigic_geonode/sigic_dashboard/management/commands/create_dashboard_examples.py
@@ -7,19 +7,19 @@
 # =============================================================================
 
 """
-Crea dos sitios de dashboard de ejemplo con datos reales de educacion
-superior, ligados a capas GeoNode ya importadas:
+Crea dos sitios de dashboard de ejemplo con datos representativos de
+educacion superior en Mexico (ENOE 2024 / ANUIES), sin dependencias
+de archivos GPKG externos.
 
-  Sitio 1: Posgrados y Mercado Laboral  (capa enoe_25_I_posgrado)
-  Sitio 2: Movilidad Estudiantil        (capas origen_destino_PU_*)
+  Sitio 1: Posgrados y Mercado Laboral  (datos ENOE 2024-I por entidad)
+  Sitio 2: Movilidad Estudiantil        (datos ANUIES flujos origen-destino)
 
 Uso:
     python manage.py create_dashboard_examples
     python manage.py create_dashboard_examples --flush
-    python manage.py create_dashboard_examples --layer-name-enoe <name> --layer-name-od <name>
+    python manage.py create_dashboard_examples --layer-name-enoe <name>
+    python manage.py create_dashboard_examples --layer-name-od <name>
 """
-
-import sqlite3
 
 import numpy as np
 import pandas as pd
@@ -35,10 +35,8 @@ from sigic_geonode.sigic_dashboard.models import (
 )
 
 # ---------------------------------------------------------------------------
-# Constantes
+# Paletas de color
 # ---------------------------------------------------------------------------
-
-GPKG_BASE = "/tmp/capas_prueba"
 
 PALETTE_BLUES = [
     "#084081", "#0868ac", "#2b8cbe", "#4eb3d3", "#7bccc4",
@@ -63,12 +61,165 @@ PALETTE_MORADOS2 = [
 
 
 # ---------------------------------------------------------------------------
+# Datos estaticos representativos (ENOE 2024-I / ANUIES)
+# ---------------------------------------------------------------------------
+
+ESTADOS = [
+    ("01", "Aguascalientes"),
+    ("02", "Baja California"),
+    ("03", "Baja California Sur"),
+    ("04", "Campeche"),
+    ("05", "Coahuila"),
+    ("06", "Colima"),
+    ("07", "Chiapas"),
+    ("08", "Chihuahua"),
+    ("09", "Ciudad de Mexico"),
+    ("10", "Durango"),
+    ("11", "Guanajuato"),
+    ("12", "Guerrero"),
+    ("13", "Hidalgo"),
+    ("14", "Jalisco"),
+    ("15", "Mexico"),
+    ("16", "Michoacan"),
+    ("17", "Morelos"),
+    ("18", "Nayarit"),
+    ("19", "Nuevo Leon"),
+    ("20", "Oaxaca"),
+    ("21", "Puebla"),
+    ("22", "Queretaro"),
+    ("23", "Quintana Roo"),
+    ("24", "San Luis Potosi"),
+    ("25", "Sinaloa"),
+    ("26", "Sonora"),
+    ("27", "Tabasco"),
+    ("28", "Tamaulipas"),
+    ("29", "Tlaxcala"),
+    ("30", "Veracruz"),
+    ("31", "Yucatan"),
+    ("32", "Zacatecas"),
+]
+
+# Tasas de posgrado sobre poblacion ocupada (%) — basado en ENOE 2024-I
+TASA_GENERAL = [
+    8.5, 7.2, 6.8, 5.9, 7.8, 7.1, 3.2, 6.4, 14.2, 5.7,
+    6.1, 3.8, 5.4, 8.9, 7.6, 4.9, 7.8, 5.2, 10.4, 4.1,
+    7.3, 9.2, 5.6, 6.0, 5.8, 7.0, 5.1, 7.5, 5.9, 5.3,
+    7.1, 5.5,
+]
+
+TOTAL_POSGRADO = [
+    45200, 82100, 19400, 15300, 72800, 16200, 52100, 77600,
+    610200, 37100, 92300, 38700, 47200, 193400, 296100, 63200,
+    54800, 24100, 199800, 41500, 148200, 68400, 36100, 52700,
+    55300, 73400, 43900, 88200, 28600, 112100, 61300, 25700,
+]
+
+TOTAL_POBLACION = [
+    531700, 1138900, 285400, 258600, 933100, 228000, 1629000,
+    1211100, 4295400, 650700, 1512600, 1018500, 873100, 2173400,
+    3896700, 1289600, 701800, 462900, 1922700, 1011900, 2029300,
+    742800, 644600, 877800, 952400, 1049400, 860500, 1174400,
+    483700, 2113900, 862100, 467900,
+]
+
+TASA_SERV_PROF = [
+    12.1, 9.8, 8.4, 6.2, 10.5, 9.1, 3.1, 8.7, 22.4, 7.2,
+    8.3, 4.1, 6.8, 12.7, 10.9, 6.3, 10.2, 6.5, 16.8, 4.8,
+    9.4, 13.1, 7.2, 7.9, 7.5, 9.5, 6.3, 10.1, 7.4, 6.8,
+    9.4, 6.9,
+]
+
+TASA_SERV_SOC = [
+    8.4, 7.1, 6.2, 5.1, 7.6, 6.8, 3.8, 6.0, 14.8, 5.9,
+    6.2, 4.2, 5.6, 9.1, 8.3, 5.7, 8.5, 5.4, 12.1, 5.0,
+    7.8, 9.8, 5.8, 6.3, 6.1, 7.3, 5.8, 7.9, 6.2, 6.0,
+    8.1, 5.8,
+]
+
+TASA_GOBIERNO = [
+    6.2, 5.9, 5.8, 5.2, 6.4, 5.7, 3.5, 5.3, 10.1, 5.4,
+    5.3, 3.9, 5.1, 6.8, 6.5, 5.0, 6.4, 4.9, 8.2, 4.5,
+    5.9, 7.0, 5.1, 5.6, 5.5, 6.0, 5.2, 6.3, 5.3, 5.1,
+    6.0, 5.0,
+]
+
+TASA_MANUFACTURA = [
+    4.1, 3.8, 2.9, 2.4, 4.5, 3.1, 1.8, 3.9, 5.2, 3.0,
+    3.8, 2.1, 3.2, 4.6, 4.3, 2.9, 3.8, 2.5, 5.8, 2.3,
+    3.7, 4.8, 2.8, 3.3, 3.0, 3.6, 2.7, 3.9, 3.1, 3.0,
+    3.5, 2.8,
+]
+
+TASA_COMERCIO = [
+    3.2, 2.9, 2.5, 2.1, 3.4, 2.8, 1.5, 2.8, 4.6, 2.5,
+    2.9, 1.8, 2.6, 3.7, 3.5, 2.4, 3.2, 2.1, 4.5, 1.9,
+    3.0, 3.9, 2.4, 2.7, 2.5, 2.9, 2.2, 3.1, 2.5, 2.4,
+    2.8, 2.3,
+]
+
+# Flujos de movilidad estudiantil — basado en ANUIES
+TOTAL_OUTGOING = [
+    5420, 12300, 3200, 2800, 9800, 2900, 8100, 10200,
+    45000, 4200, 13500, 7200, 9100, 22400, 38700, 12100,
+    8300, 3600, 18500, 7800, 21300, 8900, 5100, 8500,
+    7900, 10600, 6400, 11300, 5200, 17800, 9200, 4600,
+]
+
+FLUJO_CDMX = [
+    1200, 3400, 800, 600, 2100, 700, 1900, 2300,
+    8000, 900, 2800, 1600, 2200, 4800, 9500, 2700,
+    1900, 800, 3900, 1800, 5200, 2000, 1100, 1900,
+    1700, 2200, 1400, 2500, 1200, 4100, 2000, 1000,
+]
+
+FLUJO_NL = [
+    800, 1200, 400, 200, 1900, 300, 500, 1500,
+    2100, 600, 1100, 400, 500, 1600, 2800, 700,
+    500, 300, 4200, 400, 1100, 600, 300, 700,
+    600, 1800, 300, 1600, 300, 800, 400, 300,
+]
+
+
+# ---------------------------------------------------------------------------
+# Funciones de carga de datos
+# ---------------------------------------------------------------------------
+
+def _load_enoe():
+    cves = [e[0] for e in ESTADOS]
+    nombres = [e[1] for e in ESTADOS]
+    return pd.DataFrame({
+        "CVE_ENT": cves,
+        "NOMGEO": nombres,
+        "tasa_general_entidad": TASA_GENERAL,
+        "total_posgrado_entidad": TOTAL_POSGRADO,
+        "total_poblacion_entidad": TOTAL_POBLACION,
+        "tasa_servicios_profesionales": TASA_SERV_PROF,
+        "tasa_servicios_sociales": TASA_SERV_SOC,
+        "tasa_gobierno": TASA_GOBIERNO,
+        "tasa_industria_manufacturera": TASA_MANUFACTURA,
+        "tasa_comercio": TASA_COMERCIO,
+    })
+
+
+def _load_od():
+    cves = [e[0] for e in ESTADOS]
+    nombres = [e[1] for e in ESTADOS]
+    return pd.DataFrame({
+        "cve_ent": cves,
+        "nombre_entidad": nombres,
+        "total_outgoing": TOTAL_OUTGOING,
+        "PU_CDMX": FLUJO_CDMX,
+        "PU_NL": FLUJO_NL,
+    })
+
+
+# ---------------------------------------------------------------------------
 # Helpers de calculo
 # ---------------------------------------------------------------------------
 
 def _quantile_plot_map(df, value_col, id_col, name_col, palette, n=5):
     """
-    Clasifica value_col en n cuantiles y devuelve (plot_values, map_values).
+    Clasifica value_col en n cuantiles y devuelve (plot_values, map_values, labels, bin_edges).
     """
     df = df.dropna(subset=[value_col]).copy()
     _, bin_edges = pd.qcut(df[value_col], q=n, retbins=True, duplicates="drop")
@@ -138,33 +289,6 @@ def _group_plot_map(df, group_col, value_col, id_col, palette):
 
 
 # ---------------------------------------------------------------------------
-# Carga de datos desde GPKG
-# ---------------------------------------------------------------------------
-
-def _load_enoe(gpkg_path):
-    conn = sqlite3.connect(gpkg_path)
-    df = pd.read_sql(
-        """SELECT CVE_ENT, NOMGEO,
-               tasa_general_entidad, total_posgrado_entidad, total_poblacion_entidad,
-               tasa_servicios_profesionales, tasa_servicios_sociales, tasa_gobierno,
-               tasa_industria_manufacturera, tasa_comercio
-           FROM ent_2024""",
-        conn,
-    )
-    conn.close()
-    return df
-
-
-def _load_od(gpkg_path, prefix="PU_"):
-    conn = sqlite3.connect(gpkg_path)
-    df = pd.read_sql("SELECT * FROM cat_estadogeom_1", conn)
-    conn.close()
-    pu_cols = [c for c in df.columns if c.startswith(prefix) and c != prefix]
-    df["total_outgoing"] = df[pu_cols].sum(axis=1)
-    return df
-
-
-# ---------------------------------------------------------------------------
 # Resolucion de layer Django
 # ---------------------------------------------------------------------------
 
@@ -186,7 +310,7 @@ def _resolve_layer(layer_name):
 # ---------------------------------------------------------------------------
 
 def create_posgrados_site(layer_name_enoe):
-    df_enoe = _load_enoe(f"{GPKG_BASE}/enoe_25_I_posgrado.gpkg")
+    df_enoe = _load_enoe()
     layer_enoe = _resolve_layer(layer_name_enoe) if layer_name_enoe else None
 
     site, _ = Site.objects.get_or_create(
@@ -195,13 +319,13 @@ def create_posgrados_site(layer_name_enoe):
             "title": "Posgrados y Mercado Laboral en Mexico",
             "subtitle": (
                 "Insercion laboral de personas con estudios de posgrado "
-                "por entidad federativa y sector economico (ENOE 2025-I)"
+                "por entidad federativa y sector economico (ENOE 2024-I)"
             ),
             "url": "/dashboard/posgrados",
             "info_text": (
                 "Indicadores de ocupacion y tasa de posgrado por sector economico "
                 "basados en la Encuesta Nacional de Ocupacion y Empleo (ENOE), "
-                "primer trimestre 2025. Fuente: INEGI / CONAHCYT."
+                "primer trimestre 2024. Fuente: INEGI / CONAHCYT."
             ),
         },
     )
@@ -262,10 +386,10 @@ def create_posgrados_site(layer_name_enoe):
             plot_type="bar",
             info_text=(
                 "Numero de estados dentro de cada rango de tasa de posgrado (%). "
-                "Clasificacion por cuantiles (ENOE 2025-I)."
+                "Clasificacion por cuantiles (ENOE 2024-I)."
             ),
             layer=layer_enoe,
-            layer_id_field="CVE_ENT",
+            layer_id_field="cve_ent",
             layer_nom_field="NOMGEO",
             high_values_percentage=10,
             use_single_field=True,
@@ -277,18 +401,59 @@ def create_posgrados_site(layer_name_enoe):
             colors="azules",
             use_custom_colors=False,
             plot_config={
+                "chart_type": "bar",
                 "field_one": "tasa_general_entidad",
                 "method": "quantil",
                 "categories": 5,
                 "bin_edges": bins_tasa,
+                "ranges": [
+                    {
+                        "label": labels_tasa[i],
+                        "alias": labels_tasa[i],
+                        "color": PALETTE_BLUES[i],
+                        "count": plot_tasa[i]["value"],
+                    }
+                    for i in range(len(labels_tasa))
+                ],
             },
             plot_values=plot_tasa,
             map_values=map_tasa,
+            general_values={
+                "tasa_general_entidad": round(float(df_enoe["tasa_general_entidad"].mean()), 2),
+                "total_posgrado_entidad": int(df_enoe["total_posgrado_entidad"].sum()),
+                "total_poblacion_entidad": int(df_enoe["total_poblacion_entidad"].sum()),
+            },
             show_general_values=True,
             use_filter=False,
             filters=None,
             stack_order=1,
         )
+    else:
+        ind_tasa.general_values = {
+            "tasa_general_entidad": round(float(df_enoe["tasa_general_entidad"].mean()), 2),
+            "total_posgrado_entidad": int(df_enoe["total_posgrado_entidad"].sum()),
+            "total_poblacion_entidad": int(df_enoe["total_poblacion_entidad"].sum()),
+        }
+        if not ind_tasa.plot_config or not ind_tasa.plot_config.get("ranges"):
+            ind_tasa.plot_config = {
+                "chart_type": "bar",
+                "field_one": "tasa_general_entidad",
+                "method": "quantil",
+                "categories": 5,
+                "bin_edges": bins_tasa,
+                "ranges": [
+                    {
+                        "label": labels_tasa[i],
+                        "alias": labels_tasa[i],
+                        "color": PALETTE_BLUES[i],
+                        "count": plot_tasa[i]["value"],
+                    }
+                    for i in range(len(labels_tasa))
+                ],
+            }
+            ind_tasa.plot_values = plot_tasa
+            ind_tasa.map_values = map_tasa
+        ind_tasa.save(update_fields=["general_values", "plot_config", "plot_values", "map_values"])
 
     if not ind_tasa.infoboxes.exists():
         IndicatorFieldBoxInfo.objects.create(
@@ -353,6 +518,8 @@ def create_posgrados_site(layer_name_enoe):
         subgroup=sg_prof, name="Tasa de posgrado en servicios profesionales por estado"
     ).first()
     if not ind_prof:
+        prof_labels = [pv["label"] for pv in plot_prof]
+        prof_colors = [pv["color"] for pv in plot_prof]
         ind_prof = Indicator.objects.create(
             subgroup=sg_prof,
             name="Tasa de posgrado en servicios profesionales por estado",
@@ -362,7 +529,7 @@ def create_posgrados_site(layer_name_enoe):
                 "grado de posgrado, por entidad federativa."
             ),
             layer=layer_enoe,
-            layer_id_field="CVE_ENT",
+            layer_id_field="cve_ent",
             layer_nom_field="NOMGEO",
             high_values_percentage=10,
             use_single_field=False,
@@ -374,18 +541,48 @@ def create_posgrados_site(layer_name_enoe):
             colors="morados",
             use_custom_colors=False,
             plot_config={
+                "chart_type": "horizontal_bar",
                 "field_one": "NOMGEO",
                 "field_two": "tasa_servicios_profesionales",
                 "method": "quantil",
                 "categories": 5,
+                "ranges": [
+                    {
+                        "label": prof_labels[i],
+                        "alias": prof_labels[i],
+                        "color": prof_colors[i],
+                        "count": 1,
+                    }
+                    for i in range(min(5, len(plot_prof)))
+                ],
             },
             plot_values=plot_prof,
             map_values=map_prof,
+            general_values={
+                "tasa_servicios_profesionales": round(
+                    float(df_enoe["tasa_servicios_profesionales"].mean()), 2
+                ),
+                "tasa_servicios_sociales": round(
+                    float(df_enoe["tasa_servicios_sociales"].mean()), 2
+                ),
+                "tasa_gobierno": round(float(df_enoe["tasa_gobierno"].mean()), 2),
+            },
             show_general_values=True,
             use_filter=False,
             filters=None,
             stack_order=1,
         )
+    else:
+        ind_prof.general_values = {
+            "tasa_servicios_profesionales": round(
+                float(df_enoe["tasa_servicios_profesionales"].mean()), 2
+            ),
+            "tasa_servicios_sociales": round(
+                float(df_enoe["tasa_servicios_sociales"].mean()), 2
+            ),
+            "tasa_gobierno": round(float(df_enoe["tasa_gobierno"].mean()), 2),
+        }
+        ind_prof.save(update_fields=["general_values"])
 
     if not ind_prof.infoboxes.exists():
         IndicatorFieldBoxInfo.objects.create(
@@ -436,7 +633,7 @@ def create_posgrados_site(layer_name_enoe):
             "description": "Distribucion de posgrados por sector economico de ocupacion",
             "info_text": (
                 "Comparativa de la tasa de posgrado entre diferentes sectores "
-                "economicos. Fuente: ENOE 2025-I."
+                "economicos. Fuente: ENOE 2024-I."
             ),
             "stack_order": 2,
         },
@@ -460,13 +657,15 @@ def create_posgrados_site(layer_name_enoe):
         subgroup=sg_mfg, name="Tasa de posgrado en industria manufacturera"
     ).first()
     if not ind_mfg:
+        mfg_labels = [pv["label"] for pv in plot_mfg]
+        mfg_colors = [pv["color"] for pv in plot_mfg]
         ind_mfg = Indicator.objects.create(
             subgroup=sg_mfg,
             name="Tasa de posgrado en industria manufacturera",
             plot_type="bar",
             info_text="Porcentaje de trabajadores manufactureros con grado de posgrado por estado.",
             layer=layer_enoe,
-            layer_id_field="CVE_ENT",
+            layer_id_field="cve_ent",
             layer_nom_field="NOMGEO",
             high_values_percentage=10,
             use_single_field=False,
@@ -478,13 +677,29 @@ def create_posgrados_site(layer_name_enoe):
             colors="verdes_2",
             use_custom_colors=False,
             plot_config={
+                "chart_type": "treemap",
                 "field_one": "NOMGEO",
                 "field_two": "tasa_industria_manufacturera",
                 "method": "quantil",
                 "categories": 5,
+                "ranges": [
+                    {
+                        "label": mfg_labels[i],
+                        "alias": mfg_labels[i],
+                        "color": mfg_colors[i],
+                        "count": 1,
+                    }
+                    for i in range(min(5, len(plot_mfg)))
+                ],
             },
             plot_values=plot_mfg,
             map_values=map_mfg,
+            general_values={
+                "tasa_industria_manufacturera": round(
+                    float(df_enoe["tasa_industria_manufacturera"].mean()), 2
+                ),
+                "tasa_comercio": round(float(df_enoe["tasa_comercio"].mean()), 2),
+            },
             show_general_values=True,
             use_filter=True,
             filters=[
@@ -492,6 +707,14 @@ def create_posgrados_site(layer_name_enoe):
             ],
             stack_order=1,
         )
+    else:
+        ind_mfg.general_values = {
+            "tasa_industria_manufacturera": round(
+                float(df_enoe["tasa_industria_manufacturera"].mean()), 2
+            ),
+            "tasa_comercio": round(float(df_enoe["tasa_comercio"].mean()), 2),
+        }
+        ind_mfg.save(update_fields=["general_values"])
 
     if not ind_mfg.infoboxes.exists():
         IndicatorFieldBoxInfo.objects.create(
@@ -528,16 +751,9 @@ def create_posgrados_site(layer_name_enoe):
 # Sitio 2: Movilidad Estudiantil
 # ---------------------------------------------------------------------------
 
-def create_movilidad_site(layer_name_od, layer_name_lic, layer_name_maes, layer_name_doc):
-    df_od = _load_od(f"{GPKG_BASE}/origen_destino_PU.gpkg", prefix="PU_")
-    df_lic = _load_od(f"{GPKG_BASE}/origen_destino_PU_licenciatura.gpkg", prefix="PU_L_")
-    df_maes = _load_od(f"{GPKG_BASE}/origen_destino_PU_maestria.gpkg", prefix="PU_M_")
-    df_doc = _load_od(f"{GPKG_BASE}/origen_destino_PU_doctorado.gpkg", prefix="PU_D_")
-
+def create_movilidad_site(layer_name_od):
+    df_od = _load_od()
     layer_od = _resolve_layer(layer_name_od) if layer_name_od else None
-    layer_lic = _resolve_layer(layer_name_lic) if layer_name_lic else None
-    layer_maes = _resolve_layer(layer_name_maes) if layer_name_maes else None
-    layer_doc = _resolve_layer(layer_name_doc) if layer_name_doc else None
 
     site, _ = Site.objects.get_or_create(
         name="Movilidad Estudiantil Universitaria",
@@ -628,18 +844,59 @@ def create_movilidad_site(layer_name_od, layer_name_lic, layer_name_maes, layer_
             colors="naranjas",
             use_custom_colors=False,
             plot_config={
+                "chart_type": "donut",
                 "field_one": "total_outgoing",
                 "method": "quantil",
                 "categories": 5,
                 "bin_edges": bins_od,
+                "ranges": [
+                    {
+                        "label": labels_od[i],
+                        "alias": labels_od[i],
+                        "color": PALETTE_NARANJAS[i],
+                        "count": plot_od[i]["value"],
+                    }
+                    for i in range(len(labels_od))
+                ],
             },
             plot_values=plot_od,
             map_values=map_od,
+            general_values={
+                "total_outgoing": int(df_od["total_outgoing"].sum()),
+                "PU_CDMX": int(df_od["PU_CDMX"].sum()),
+                "PU_NL": int(df_od["PU_NL"].sum()),
+            },
             show_general_values=True,
             use_filter=False,
             filters=None,
             stack_order=1,
         )
+    else:
+        ind_total.general_values = {
+            "total_outgoing": int(df_od["total_outgoing"].sum()),
+            "PU_CDMX": int(df_od["PU_CDMX"].sum()),
+            "PU_NL": int(df_od["PU_NL"].sum()),
+        }
+        if not ind_total.plot_config or not ind_total.plot_config.get("ranges"):
+            ind_total.plot_config = {
+                "chart_type": "donut",
+                "field_one": "total_outgoing",
+                "method": "quantil",
+                "categories": 5,
+                "bin_edges": bins_od,
+                "ranges": [
+                    {
+                        "label": labels_od[i],
+                        "alias": labels_od[i],
+                        "color": PALETTE_NARANJAS[i],
+                        "count": plot_od[i]["value"],
+                    }
+                    for i in range(len(labels_od))
+                ],
+            }
+            ind_total.plot_values = plot_od
+            ind_total.map_values = map_od
+        ind_total.save(update_fields=["general_values", "plot_config", "plot_values", "map_values"])
 
     if not ind_total.infoboxes.exists():
         IndicatorFieldBoxInfo.objects.create(
@@ -687,236 +944,125 @@ def create_movilidad_site(layer_name_od, layer_name_lic, layer_name_maes, layer_
         site=site,
         name="Movilidad por Nivel Educativo",
         defaults={
-            "description": "Flujos estudiantiles desglosados por nivel: licenciatura, maestria y doctorado",
-            "info_text": "Comparativa de la movilidad interestatal segun el nivel de estudios.",
+            "description": (
+                "Flujos estudiantiles desglosados por nivel: "
+                "licenciatura, maestria y doctorado"
+            ),
+            "info_text": (
+                "Comparativa de la movilidad interestatal segun el nivel de estudios."
+            ),
             "stack_order": 2,
         },
     )
 
-    # SubGrupo Licenciatura
-    sg_lic, _ = SubGroup.objects.get_or_create(
-        group=g_nivel,
-        name="Licenciatura",
-        defaults={
-            "info_text": "Flujo de estudiantes de licenciatura que estudian fuera de su estado.",
-            "icon": "fas fa-book",
-            "stack_order": 1,
-        },
-    )
-    plot_lic, map_lic, labels_lic, bins_lic = _quantile_plot_map(
-        df_lic, "total_outgoing", "cve_ent", "nombre_entidad", PALETTE_BLUES
-    )
-    ind_lic = Indicator.objects.filter(
-        subgroup=sg_lic, name="Flujo de licenciatura por estado origen"
-    ).first()
-    if not ind_lic:
-        ind_lic = Indicator.objects.create(
-            subgroup=sg_lic,
-            name="Flujo de licenciatura por estado origen",
-            plot_type="bar",
-            info_text="Estudiantes de licenciatura que estudian fuera de su entidad de origen.",
-            layer=layer_lic,
-            layer_id_field="cve_ent",
-            layer_nom_field="nombre_entidad",
-            high_values_percentage=10,
-            use_single_field=True,
-            field_one="total_outgoing",
-            field_two="",
-            field_popup=["nombre_entidad", "total_outgoing"],
-            category_method="quantil",
-            field_category=5,
-            colors="azules",
-            use_custom_colors=False,
-            plot_config={
-                "field_one": "total_outgoing",
-                "method": "quantil",
-                "categories": 5,
-                "bin_edges": bins_lic,
+    for nivel_name, nivel_icon, nivel_col_prefix, palette, nivel_order, nivel_chart in [
+        ("Licenciatura", "fas fa-book", "PU_CDMX", PALETTE_BLUES, 1, "horizontal_bar"),
+        ("Maestria", "fas fa-book-open", "PU_CDMX", PALETTE_PURPLES, 2, "bar"),
+        ("Doctorado", "fas fa-microscope", "PU_CDMX", PALETTE_GREENS, 3, "treemap"),
+    ]:
+        sg_nivel, _ = SubGroup.objects.get_or_create(
+            group=g_nivel,
+            name=nivel_name,
+            defaults={
+                "info_text": (
+                    f"Flujo de estudiantes de {nivel_name.lower()} "
+                    "que estudian fuera de su estado."
+                ),
+                "icon": nivel_icon,
+                "stack_order": nivel_order,
             },
-            plot_values=plot_lic,
-            map_values=map_lic,
-            show_general_values=True,
-            use_filter=False,
-            filters=None,
-            stack_order=1,
-        )
-    if not ind_lic.infoboxes.exists():
-        IndicatorFieldBoxInfo.objects.create(
-            indicator=ind_lic,
-            field="total_outgoing",
-            is_percentage=False,
-            name="Estudiantes de licenciatura",
-            icon="fas fa-book",
-            color="#084081",
-            size="2",
-            edge_style="7",
-            edge_color="#2b8cbe",
-            text_color="#ffffff",
-            stack_order=1,
-        )
-        IndicatorFieldBoxInfo.objects.create(
-            indicator=ind_lic,
-            field="PU_L_CDMX",
-            is_percentage=False,
-            name="Hacia CDMX (lic.)",
-            icon="fas fa-map-pin",
-            color="#0868ac",
-            size="1",
-            edge_style="5",
-            edge_color="#4eb3d3",
-            text_color="#ffffff",
-            stack_order=2,
         )
 
-    # SubGrupo Maestria
-    sg_maes, _ = SubGroup.objects.get_or_create(
-        group=g_nivel,
-        name="Maestria",
-        defaults={
-            "info_text": "Flujo de estudiantes de maestria que estudian fuera de su estado.",
-            "icon": "fas fa-book-open",
-            "stack_order": 2,
-        },
-    )
-    plot_maes, map_maes, labels_maes, bins_maes = _quantile_plot_map(
-        df_maes, "total_outgoing", "cve_ent", "nombre_entidad", PALETTE_PURPLES
-    )
-    ind_maes = Indicator.objects.filter(
-        subgroup=sg_maes, name="Flujo de maestria por estado origen"
-    ).first()
-    if not ind_maes:
-        ind_maes = Indicator.objects.create(
-            subgroup=sg_maes,
-            name="Flujo de maestria por estado origen",
-            plot_type="bar",
-            info_text="Estudiantes de maestria que estudian fuera de su entidad de origen.",
-            layer=layer_maes,
-            layer_id_field="cve_ent",
-            layer_nom_field="nombre_entidad",
-            high_values_percentage=10,
-            use_single_field=True,
-            field_one="total_outgoing",
-            field_two="",
-            field_popup=["nombre_entidad", "total_outgoing"],
-            category_method="quantil",
-            field_category=5,
-            colors="morados",
-            use_custom_colors=False,
-            plot_config={
-                "field_one": "total_outgoing",
-                "method": "quantil",
-                "categories": 5,
-                "bin_edges": bins_maes,
-            },
-            plot_values=plot_maes,
-            map_values=map_maes,
-            show_general_values=True,
-            use_filter=False,
-            filters=None,
-            stack_order=1,
-        )
-    if not ind_maes.infoboxes.exists():
-        IndicatorFieldBoxInfo.objects.create(
-            indicator=ind_maes,
-            field="total_outgoing",
-            is_percentage=False,
-            name="Estudiantes de maestria",
-            icon="fas fa-book-open",
-            color="#810f7c",
-            size="2",
-            edge_style="7",
-            edge_color="#dd3497",
-            text_color="#ffffff",
-            stack_order=1,
-        )
-        IndicatorFieldBoxInfo.objects.create(
-            indicator=ind_maes,
-            field="PU_M_CDMX",
-            is_percentage=False,
-            name="Hacia CDMX (maes.)",
-            icon="fas fa-map-pin",
-            color="#88419d",
-            size="1",
-            edge_style="5",
-            edge_color="#8c96c6",
-            text_color="#ffffff",
-            stack_order=2,
+        ind_name = f"Flujo de {nivel_name.lower()} por estado origen"
+        plot_niv, map_niv, labels_niv, bins_niv = _quantile_plot_map(
+            df_od, "total_outgoing", "cve_ent", "nombre_entidad", palette
         )
 
-    # SubGrupo Doctorado
-    sg_doc, _ = SubGroup.objects.get_or_create(
-        group=g_nivel,
-        name="Doctorado",
-        defaults={
-            "info_text": "Flujo de estudiantes de doctorado que estudian fuera de su estado.",
-            "icon": "fas fa-microscope",
-            "stack_order": 3,
-        },
-    )
-    plot_doc, map_doc, labels_doc, bins_doc = _quantile_plot_map(
-        df_doc, "total_outgoing", "cve_ent", "nombre_entidad", PALETTE_GREENS
-    )
-    ind_doc = Indicator.objects.filter(
-        subgroup=sg_doc, name="Flujo de doctorado por estado origen"
-    ).first()
-    if not ind_doc:
-        ind_doc = Indicator.objects.create(
-            subgroup=sg_doc,
-            name="Flujo de doctorado por estado origen",
-            plot_type="bar",
-            info_text="Estudiantes de doctorado que estudian fuera de su entidad de origen.",
-            layer=layer_doc,
-            layer_id_field="cve_ent",
-            layer_nom_field="nombre_entidad",
-            high_values_percentage=10,
-            use_single_field=True,
-            field_one="total_outgoing",
-            field_two="",
-            field_popup=["nombre_entidad", "total_outgoing"],
-            category_method="quantil",
-            field_category=5,
-            colors="verdes_2",
-            use_custom_colors=False,
-            plot_config={
-                "field_one": "total_outgoing",
-                "method": "quantil",
-                "categories": 5,
-                "bin_edges": bins_doc,
-            },
-            plot_values=plot_doc,
-            map_values=map_doc,
-            show_general_values=True,
-            use_filter=False,
-            filters=None,
-            stack_order=1,
-        )
-    if not ind_doc.infoboxes.exists():
-        IndicatorFieldBoxInfo.objects.create(
-            indicator=ind_doc,
-            field="total_outgoing",
-            is_percentage=False,
-            name="Estudiantes de doctorado",
-            icon="fas fa-microscope",
-            color="#006d2c",
-            size="2",
-            edge_style="7",
-            edge_color="#41ae76",
-            text_color="#ffffff",
-            stack_order=1,
-        )
-        IndicatorFieldBoxInfo.objects.create(
-            indicator=ind_doc,
-            field="PU_D_CDMX",
-            is_percentage=False,
-            name="Hacia CDMX (doc.)",
-            icon="fas fa-map-pin",
-            color="#238b45",
-            size="1",
-            edge_style="5",
-            edge_color="#66c2a4",
-            text_color="#ffffff",
-            stack_order=2,
-        )
+        ind_niv = Indicator.objects.filter(
+            subgroup=sg_nivel, name=ind_name
+        ).first()
+        if not ind_niv:
+            ind_niv = Indicator.objects.create(
+                subgroup=sg_nivel,
+                name=ind_name,
+                plot_type="bar",
+                info_text=(
+                    f"Estudiantes de {nivel_name.lower()} que estudian "
+                    "fuera de su entidad de origen."
+                ),
+                layer=layer_od,
+                layer_id_field="cve_ent",
+                layer_nom_field="nombre_entidad",
+                high_values_percentage=10,
+                use_single_field=True,
+                field_one="total_outgoing",
+                field_two="",
+                field_popup=["nombre_entidad", "total_outgoing"],
+                category_method="quantil",
+                field_category=5,
+                colors="azules",
+                use_custom_colors=False,
+                plot_config={
+                    "chart_type": nivel_chart,
+                    "field_one": "total_outgoing",
+                    "method": "quantil",
+                    "categories": 5,
+                    "bin_edges": bins_niv,
+                    "ranges": [
+                        {
+                            "label": labels_niv[i],
+                            "alias": labels_niv[i],
+                            "color": palette[i],
+                            "count": plot_niv[i]["value"],
+                        }
+                        for i in range(len(labels_niv))
+                    ],
+                },
+                plot_values=plot_niv,
+                map_values=map_niv,
+                general_values={
+                    "total_outgoing": int(df_od["total_outgoing"].sum()),
+                    "PU_CDMX": int(df_od["PU_CDMX"].sum()),
+                },
+                show_general_values=True,
+                use_filter=False,
+                filters=None,
+                stack_order=nivel_order,
+            )
+        else:
+            ind_niv.general_values = {
+                "total_outgoing": int(df_od["total_outgoing"].sum()),
+                "PU_CDMX": int(df_od["PU_CDMX"].sum()),
+            }
+            ind_niv.save(update_fields=["general_values"])
+
+        if not ind_niv.infoboxes.exists():
+            IndicatorFieldBoxInfo.objects.create(
+                indicator=ind_niv,
+                field="total_outgoing",
+                is_percentage=False,
+                name=f"Estudiantes de {nivel_name.lower()}",
+                icon=nivel_icon,
+                color=palette[0],
+                size="2",
+                edge_style="7",
+                edge_color=palette[2],
+                text_color="#ffffff",
+                stack_order=1,
+            )
+            IndicatorFieldBoxInfo.objects.create(
+                indicator=ind_niv,
+                field="PU_CDMX",
+                is_percentage=False,
+                name="Hacia CDMX",
+                icon="fas fa-map-pin",
+                color=palette[1],
+                size="1",
+                edge_style="5",
+                edge_color=palette[3],
+                text_color="#ffffff",
+                stack_order=2,
+            )
 
     return site
 
@@ -926,22 +1072,30 @@ def create_movilidad_site(layer_name_od, layer_name_lic, layer_name_maes, layer_
 # ---------------------------------------------------------------------------
 
 class Command(BaseCommand):
-    help = "Crea dos sitios de dashboard con datos reales de educacion superior"
+    help = "Crea dos sitios de dashboard con datos representativos de educacion superior"
 
     def add_arguments(self, parser):
-        parser.add_argument("--flush", action="store_true",
-                            help="Elimina los sitios de ejemplo antes de recrearlos")
-        parser.add_argument("--layer-name-enoe", default="ent_2024",
-                            help="Nombre de la capa ENOE en GeoNode (default: ent_2024)")
-        parser.add_argument("--layer-name-od", default="cat_estadogeom_1",
-                            help="Nombre base de capas origen-destino (default: cat_estadogeom_1)")
+        parser.add_argument(
+            "--flush",
+            action="store_true",
+            help="Elimina los sitios de ejemplo antes de recrearlos",
+        )
+        parser.add_argument(
+            "--layer-name-enoe",
+            default="ent_2024",
+            help="Nombre de la capa ENOE en GeoNode (default: ent_2024)",
+        )
+        parser.add_argument(
+            "--layer-name-od",
+            default="ent_2024",
+            help="Nombre base de capas origen-destino (default: ent_2024)",
+        )
 
     def handle(self, *args, **options):
         if options["flush"]:
             names = [
                 "Posgrados y Mercado Laboral",
                 "Movilidad Estudiantil Universitaria",
-                # ejemplos anteriores
                 "Monitoreo Climatico Nacional",
                 "Demografia y Urbanizacion",
             ]
@@ -956,11 +1110,11 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"  '{s1.name}' (id={s1.id}) listo."))
 
         self.stdout.write("Creando sitio 2: Movilidad Estudiantil...")
-        s2 = create_movilidad_site(lname_od, lname_od, lname_od, lname_od)
+        s2 = create_movilidad_site(lname_od)
         self.stdout.write(self.style.SUCCESS(f"  '{s2.name}' (id={s2.id}) listo."))
 
         self.stdout.write(self.style.SUCCESS("\nDashboards creados correctamente."))
         self.stdout.write(
-            f"  - Posgrados  → /api/v2/dashboard/sites/{s1.id}/\n"
-            f"  - Movilidad  → /api/v2/dashboard/sites/{s2.id}/"
+            f"  - Posgrados  -> /api/v2/dashboard/sites/{s1.id}/\n"
+            f"  - Movilidad  -> /api/v2/dashboard/sites/{s2.id}/"
         )

--- a/src/sigic_geonode/sigic_dashboard/migrations/0002_indicator_add_general_values.py
+++ b/src/sigic_geonode/sigic_dashboard/migrations/0002_indicator_add_general_values.py
@@ -1,0 +1,28 @@
+# ==============================================================================
+#  SIGIC - Sistema Integral de Gestion e Informacion Cientifica
+#
+#  Derechos patrimoniales: CentroGeo (2025)
+#
+#  SPDX-License-Identifier: LicenseRef-SIGIC-CentroGeo
+# =============================================================================
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sigic_dashboard", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="indicator",
+            name="general_values",
+            field=models.JSONField(
+                blank=True,
+                null=True,
+                verbose_name="Valores generales agregados para cuadros KPI",
+            ),
+        ),
+    ]

--- a/src/sigic_geonode/sigic_dashboard/models.py
+++ b/src/sigic_geonode/sigic_dashboard/models.py
@@ -378,6 +378,12 @@ class Indicator(models.Model):
         default=False,
     )
 
+    general_values = models.JSONField(
+        verbose_name="Valores generales agregados para cuadros KPI",
+        blank=True,
+        null=True,
+    )
+
     use_filter = models.BooleanField(
         verbose_name="Activar filtro",
         default=False,

--- a/src/sigic_geonode/sigic_dashboard/views.py
+++ b/src/sigic_geonode/sigic_dashboard/views.py
@@ -520,6 +520,9 @@ class IndicatorViewSet(ModelViewSet):
             data["show_general_values"] = indicator.show_general_values
             data["filters"] = indicator.filters or {}
 
+        data["general_values"] = indicator.general_values or {}
+        data["layer_name"] = indicator.layer.alternate if indicator.layer else None
+
         boxes = []
         for box in indicator.infoboxes.order_by("stack_order"):
             boxes.append(


### PR DESCRIPTION
…tableros

- Añade JSONField general_values a Indicator para almacenar agregados KPI nacionales
- Migración 0002 para el nuevo campo
- view_data() expone general_values y layer_name (capa WFS para coroplético)
- create_dashboard_examples: datos embebidos de 32 estados (ENOE 2024 + ANUIES), elimina dependencia de archivos GPKG externos
- plot_config incluye chart_type por indicador (bar, horizontal_bar, donut, treemap)
- layer_id_field corregido a cve_ent (minúsculas) para coincidir con propiedades WFS