### PR TITLE
feat(tableros): paletas inversas, bbox en indicador y privacidad por defecto

### DIFF
--- a/src/sigic_geonode/sigic_dashboard/migrations/0007_site_is_public_default_false.py
+++ b/src/sigic_geonode/sigic_dashboard/migrations/0007_site_is_public_default_false.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sigic_dashboard", "0006_indicator_general_values"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="site",
+            name="is_public",
+            field=models.BooleanField(
+                default=False,
+                help_text="Si es verdadero el tablero es visible para todos los usuarios",
+                verbose_name="Público",
+            ),
+        ),
+    ]

--- a/src/sigic_geonode/sigic_dashboard/models.py
+++ b/src/sigic_geonode/sigic_dashboard/models.py
@@ -97,7 +97,7 @@ class Site(models.Model):
 
     is_public = models.BooleanField(
         verbose_name="Público",
-        default=True,
+        default=False,
         help_text="Si es verdadero el tablero es visible para todos los usuarios",
     )
 

--- a/src/sigic_geonode/sigic_dashboard/utils/indicator_utils.py
+++ b/src/sigic_geonode/sigic_dashboard/utils/indicator_utils.py
@@ -290,7 +290,13 @@ def get_color_palette(palette_name):
         "verdes_6": ["#204d49", "#266e68", "#4b9b94", "#6eb5af", "#a3d9d4", "#edf8b1", "#ffffe5"],
     }
 
-    return colors_palette[palette_name]
+    if palette_name in colors_palette:
+        return colors_palette[palette_name]
+    if palette_name.endswith("_r"):
+        base = palette_name[:-2]
+        if base in colors_palette:
+            return list(reversed(colors_palette[base]))
+    return colors_palette.get("azules_3", [])
 
 
 def assign_color(data, color_selection, custom_colors=None):

--- a/src/sigic_geonode/sigic_dashboard/views.py
+++ b/src/sigic_geonode/sigic_dashboard/views.py
@@ -649,6 +649,13 @@ class IndicatorViewSet(ModelViewSet):
         except Exception:
             data["layer_name"] = None
 
+        # Bounding box de la capa para centrar el mapa (minLon, minLat, maxLon, maxLat)
+        try:
+            geom = indicator.layer.ll_bbox_polygon or indicator.layer.bbox_polygon
+            data["bbox"] = list(geom.extent) if geom else None
+        except Exception:
+            data["bbox"] = None
+
         # Valores KPI para los cuadros de datos
         if indicator.show_general_values and indicator.layer:
             try:

--- a/src/sigic_geonode/sigic_georeference/style_generator.py
+++ b/src/sigic_geonode/sigic_georeference/style_generator.py
@@ -56,24 +56,26 @@ DIVERGING_RAMPS = ["RdYlGn", "RdBu", "PuOr", "BrBG"]
 QUALITATIVE_RAMPS = ["Set1", "Set2", "Set3", "Paired", "Pastel1"]
 
 
-def _get_palette_colors(palette_name: str, n: int) -> list:
+def _get_palette_colors(palette_name: str, n: int, reverse: bool = False) -> list:
     """Return exactly n colors from the named ColorBrewer palette."""
     colors = COLOR_RAMPS.get(palette_name, [])
     if not colors:
         return []
     if n >= len(colors):
-        # Cycle for qualitative; repeat last for sequential
         result = []
         while len(result) < n:
             result.extend(colors)
-        return result[:n]
-    if palette_name in QUALITATIVE_RAMPS:
-        return colors[:n]
-    # Sequential/diverging: evenly distribute n stops across the full ramp
-    if n == 1:
-        return [colors[0]]
-    indices = [round(i * (len(colors) - 1) / (n - 1)) for i in range(n)]
-    return [colors[i] for i in indices]
+        result = result[:n]
+    elif palette_name in QUALITATIVE_RAMPS:
+        result = colors[:n]
+    else:
+        # Sequential/diverging: evenly distribute n stops across the full ramp
+        if n == 1:
+            result = [colors[0]]
+        else:
+            indices = [round(i * (len(colors) - 1) / (n - 1)) for i in range(n)]
+            result = [colors[i] for i in indices]
+    return list(reversed(result)) if reverse else result
 
 # ---------------------------------------------------------------------------
 # Column classification constants
@@ -317,10 +319,11 @@ def build_categorical_sld(
     style_name: str,
     palette_name: str = None,
     label: str = None,
+    reverse: bool = False,
 ) -> str:
     """Build a complete SLD 1.0.0 for categorical classification."""
     if palette_name:
-        palette = _get_palette_colors(palette_name, len(values)) or QUALITATIVE_PALETTE
+        palette = _get_palette_colors(palette_name, len(values), reverse=reverse) or QUALITATIVE_PALETTE
     else:
         palette = QUALITATIVE_PALETTE
     rules = []
@@ -375,11 +378,12 @@ def build_numeric_sld(
     style_name: str,
     palette_name: str = None,
     label: str = None,
+    reverse: bool = False,
 ) -> str:
     """Build a complete SLD 1.0.0 for numeric classification."""
     n = len(breaks) - 1
     if palette_name:
-        palette = _get_palette_colors(palette_name, n) or SEQUENTIAL_PALETTE_5[:n]
+        palette = _get_palette_colors(palette_name, n, reverse=reverse) or SEQUENTIAL_PALETTE_5[:n]
     else:
         palette = SEQUENTIAL_PALETTE_5[:n]
     rules = []
@@ -443,6 +447,7 @@ def build_graduated_size_sld(
     size_min: int = 6,
     size_max: int = 24,
     label: str = None,
+    reverse: bool = False,
 ) -> str:
     """
     SLD 1.0.0 para puntos con tamaño Y color graduados por clase.
@@ -453,7 +458,7 @@ def build_graduated_size_sld(
         return ""
 
     if palette_name:
-        palette = _get_palette_colors(palette_name, n) or SEQUENTIAL_PALETTE_5[:n]
+        palette = _get_palette_colors(palette_name, n, reverse=reverse) or SEQUENTIAL_PALETTE_5[:n]
     else:
         palette = SEQUENTIAL_PALETTE_5[:n]
 
@@ -799,6 +804,7 @@ def generate_and_register_styles_with_specs(ds, style_specs: list, default_col: 
             n_classes = int(spec.get("n_classes", 5))
             classification = spec.get("classification", "quantile")
             label = spec.get("label") or col_name
+            reverse = bool(spec.get("reverse", False))
 
             if not _SAFE_COL.match(col_name):
                 logger.warning(f"Skipping unsafe column name: {col_name!r}")
@@ -816,6 +822,7 @@ def generate_and_register_styles_with_specs(ds, style_specs: list, default_col: 
                         layer_name, col_name, values, geom_type, style_name,
                         palette_name=palette_name,
                         label=label,
+                        reverse=reverse,
                     )
                 elif style_type in ("graduated", "graduated_size"):
                     if classification == "equal_interval":
@@ -832,12 +839,14 @@ def generate_and_register_styles_with_specs(ds, style_specs: list, default_col: 
                             size_min=int(spec.get("size_min", 6)),
                             size_max=int(spec.get("size_max", 24)),
                             label=label,
+                            reverse=reverse,
                         )
                     else:
                         sld_body = build_numeric_sld(
                             layer_name, col_name, breaks, geom_type, style_name,
                             palette_name=palette_name,
                             label=label,
+                            reverse=reverse,
                         )
             except Exception as e:
                 logger.error(f"SLD generation failed for column {col_name}: {e}")


### PR DESCRIPTION
## Resumen

- **indicator_utils**: `get_color_palette` ahora soporta paletas con sufijo `_r` para inversión de colores (ej. `azules_3_r`)
- **views (Indicator)**: el serializer expone `bbox` de la capa para que el frontend pueda centrar el mapa automáticamente
- **models (Site)**: `is_public` cambia a `False` por defecto — los tableros nuevos son privados al crearse
- **migración 0007**: aplica el cambio de default en la base de datos existente
- **style_generator**: propaga el parámetro `reverse` a `build_categorical_sld`, `build_numeric_sld` y `build_graduated_size_sld`; `_get_palette_colors` acepta `reverse=True`

## Plan de prueba

- [ ] Crear un tablero con paleta invertida y verificar que los colores se muestran en orden inverso
- [ ] Verificar que el mapa del frontend centra correctamente usando el bbox devuelto
- [ ] Crear un tablero nuevo y confirmar que `is_public=False` por defecto
- [ ] Aplicar la migración en staging: `python manage.py migrate sigic_dashboard`