### PR TITLE
feat(importador): construcción de tablero async y mejoras de detección geográfica

### DIFF
--- a/src/sigic_geonode/sigic_data_importer/column_detector.py
+++ b/src/sigic_geonode/sigic_data_importer/column_detector.py
@@ -21,7 +21,7 @@ import pandas as pd
 _LAT_NAMES = {"lat", "latitude", "latitud", "y", "lat_dd", "latgd"}
 _LON_NAMES = {"lon", "lng", "longitude", "longitud", "x", "lon_dd", "longd", "lngd"}
 _STATE_KEY_NAMES = {"cve_ent", "cvgeo_ent", "estado_id", "clave_estado", "ent", "entidad_cve"}
-_MUN_KEY_NAMES = {"cve_mun", "cvegeo", "cve_geo", "municipio_id", "clave_municipio", "mun_id"}
+_MUN_KEY_NAMES = {"cve_mun", "cvegeo", "cve_geo", "cvegeomun", "municipio_id", "clave_municipio", "mun_id"}
 _STATE_NAME_NAMES = {"nombre_estado", "nom_ent", "entidad", "estado", "state_name", "state"}
 _MUN_NAME_NAMES = {"nombre_municipio", "nom_mun", "municipio", "municipality"}
 
@@ -185,7 +185,12 @@ def suggest_geo_strategy(schema: list) -> dict:
     """
     lat_col = next((c["name"] for c in schema if c.get("geo_role") == "lat"), None)
     lon_col = next((c["name"] for c in schema if c.get("geo_role") == "lon"), None)
-    mun_key = next((c["name"] for c in schema if c.get("geo_role") == "mun_key"), None)
+    # Prefer the 5-digit composite key (state+municipality) over the 3-digit municipal-only code
+    mun_key_cols = [c for c in schema if c.get("geo_role") == "mun_key"]
+    mun_key = next(
+        (c["name"] for c in mun_key_cols if any(len(str(v).strip()) == 5 for v in (c.get("sample_values") or []))),
+        next((c["name"] for c in mun_key_cols), None),
+    )
     state_key = next((c["name"] for c in schema if c.get("geo_role") == "state_key"), None)
     mun_name = next((c["name"] for c in schema if c.get("geo_role") == "mun_name"), None)
     state_name = next((c["name"] for c in schema if c.get("geo_role") == "state_name"), None)

--- a/src/sigic_geonode/sigic_data_importer/tablero_builder.py
+++ b/src/sigic_geonode/sigic_data_importer/tablero_builder.py
@@ -16,6 +16,8 @@ pre-calculados, infoboxes KPI, e indicadores categoricos si aplica).
 import logging
 import re
 
+import psycopg2
+from django.conf import settings
 from geonode.layers.models import Dataset
 
 from sigic_geonode.sigic_dashboard.models import (
@@ -51,19 +53,29 @@ def _slugify(text: str, max_len: int = 200) -> str:
 
 def _get_indicator_data(field_one, field_id, table_name, cast_numeric=False):
     """
-    Obtiene datos crudos de la BD de geodatos usando la conexion de utils.geodata_conn.
-    cast_numeric=True hace ::numeric sobre field_one para que process_data lo trate
+    Obtiene datos crudos de la BD de geodatos creando una conexion fresca por llamada.
+    cast_numeric=True hace ::float8 sobre field_one para que process_data lo trate
     como numero (columnas varchar importadas desde CSV llegan como strings).
     Retorna lista de tuplas (field_one_val, field_id_val) o None si falla.
     """
-    from sigic_geonode.utils.geodata_conn import connection
+    db = settings.DATABASES["datastore"]
     try:
-        connection.rollback()
+        conn = psycopg2.connect(
+            dbname=db["NAME"],
+            user=db["USER"],
+            password=db["PASSWORD"],
+            port=db["PORT"],
+            host=db["HOST"],
+        )
     except Exception:
-        pass
+        logger.exception(
+            "_get_indicator_data: no se pudo conectar a geonode_data (table=%s col=%s)",
+            table_name, field_one,
+        )
+        return None
     try:
-        with connection.cursor() as cur:
-            # ::float8 retorna float nativo de Python (no Decimal) → pandas lo infiere como float64
+        with conn.cursor() as cur:
+            # ::float8 retorna float nativo de Python → pandas lo infiere como float64
             field_expr = f'"{field_one}"::float8' if cast_numeric else f'"{field_one}"'
             cur.execute(
                 f'SELECT {field_expr}, "{field_id}" FROM "{table_name}"'
@@ -72,11 +84,9 @@ def _get_indicator_data(field_one, field_id, table_name, cast_numeric=False):
             return cur.fetchall()
     except Exception:
         logger.exception("_get_indicator_data failed for table=%s col=%s", table_name, field_one)
-        try:
-            connection.rollback()
-        except Exception:
-            pass
         return None
+    finally:
+        conn.close()
 
 
 def _detect_nom_field(schema, geo_strategy):
@@ -205,7 +215,7 @@ def build_tablero_from_job(job) -> int:
         title=site_name,
         subtitle="Tablero generado automaticamente desde datos importados",
         url=_slugify(site_name),
-        is_public=True,
+        is_public=False,
     )
 
     SiteConfiguration.objects.create(
@@ -228,9 +238,9 @@ def build_tablero_from_job(job) -> int:
 
     # Campo ID geografico segun estrategia
     if job.geo_strategy in ("latlon", "none"):
-        geo_id_field = "fid"
+        geo_id_field = "ogc_fid"
     else:
-        geo_id_field = job.geo_field_join or "fid"
+        geo_id_field = job.geo_field_join or "ogc_fid"
 
     geo_nom_field = _detect_nom_field(schema, job.geo_strategy)
 
@@ -274,18 +284,26 @@ def build_tablero_from_job(job) -> int:
     )
 
     if style_specs:
-        # Usar las columnas configuradas por el usuario en el paso de estilos
-        for idx, spec in enumerate(style_specs[:10], start=1):
+        # Priorizar numéricos primero para que no queden enterrados si hay muchos categóricos
+        numeric_specs = [s for s in style_specs if s.get("type") in ("graduated", "graduated_size")]
+        categ_specs = [s for s in style_specs if s.get("type") == "categorical"]
+        ordered_specs = numeric_specs + categ_specs
+
+        for idx, spec in enumerate(ordered_specs[:20], start=1):
             col_name = spec["col"]
             raw_label = spec.get("label") or col_name
             col_label = raw_label.replace("_", " ").title()
             palette = _DEFAULT_PALETTES[(idx - 1) % len(_DEFAULT_PALETTES)]
+            if spec.get("reverse"):
+                palette = f"{palette}_r"
 
+            is_categorical = spec.get("type") == "categorical"
+            plot_type = "donut" if is_categorical else "bar"
             indicator = Indicator.objects.create(
                 site=site,
                 group=group,
                 name=col_label,
-                plot_type="bar",
+                plot_type=plot_type,
                 layer=dataset,
                 layer_id_field=geo_id_field,
                 layer_nom_field=geo_nom_field,
@@ -296,7 +314,10 @@ def build_tablero_from_job(job) -> int:
                 stack_order=idx,
             )
 
-            _create_infobox(indicator, col_name, f"Total: {col_label}")
+            if is_categorical:
+                _create_infobox(indicator, "__count__", f"Distribución: {col_label}")
+            else:
+                _create_infobox(indicator, col_name, f"Total: {col_label}")
 
             if layer_name:
                 _pre_compute_indicator(indicator, layer_name, palette)

--- a/src/sigic_geonode/sigic_data_importer/tasks.py
+++ b/src/sigic_geonode/sigic_data_importer/tasks.py
@@ -144,6 +144,69 @@ def import_tabular_to_geonode(self, job_id: int, authorization: str):
             os.unlink(gpkg_path)
 
 
+@shared_task(
+    bind=True,
+    name="sigic_data_importer.build_tablero_task",
+    queue="default",
+    max_retries=0,
+    time_limit=600,
+    soft_time_limit=540,
+)
+def build_tablero_task(self, job_id: int, default_style_col: str = None):
+    """
+    Aplica metadatos al dataset, genera estilos en GeoServer y construye
+    el tablero de datos. Todo en segundo plano para evitar timeouts HTTP.
+    """
+    from .models import DataImportJob
+    from .tablero_builder import build_tablero_from_job
+    from .views import _apply_metadata_to_dataset
+
+    try:
+        job = DataImportJob.objects.get(pk=job_id)
+
+        # 1. Aplicar metadatos al dataset de GeoNode
+        if job.geonode_dataset_id:
+            _apply_metadata_to_dataset(
+                job,
+                job.original_filename,
+                job.layer_abstract,
+            )
+
+        # 2. Generar estilos en GeoServer
+        if job.geonode_dataset_id and job.style_specs and job.geo_strategy != "none":
+            try:
+                from geonode.layers.models import Dataset
+                from sigic_geonode.sigic_georeference.style_generator import (
+                    generate_and_register_styles_with_specs,
+                )
+                ds = Dataset.objects.filter(id=job.geonode_dataset_id).first()
+                if ds:
+                    generate_and_register_styles_with_specs(
+                        ds,
+                        job.style_specs,
+                        default_col=default_style_col or None,
+                    )
+            except Exception:
+                logger.exception("Style generation failed for job %s (non-fatal)", job_id)
+
+        # 3. Construir tablero
+        site_id = build_tablero_from_job(job)
+        job.dashboard_site_id = site_id
+        job.save(update_fields=["dashboard_site_id"])
+        logger.info("Tablero %s creado para job %s", site_id, job_id)
+
+    except DataImportJob.DoesNotExist:
+        logger.error("Job %s no encontrado en build_tablero_task", job_id)
+    except Exception as exc:
+        logger.error("Error creando tablero para job %s: %s", job_id, traceback.format_exc())
+        try:
+            job = DataImportJob.objects.get(pk=job_id)
+            job.error_message = f"Error creando tablero: {str(exc)[:400]}"
+            job.save(update_fields=["error_message"])
+        except Exception:
+            pass
+
+
 def _resolve_authorization(job, fallback: str) -> str:
     """
     Devuelve un header Authorization válido para las llamadas internas a GeoNode.

--- a/src/sigic_geonode/sigic_data_importer/views.py
+++ b/src/sigic_geonode/sigic_data_importer/views.py
@@ -95,6 +95,13 @@ class DataImporterViewSet(GenericViewSet):
         return Response(DataImportJobSerializer(job).data, status=status.HTTP_201_CREATED)
 
     # ------------------------------------------------------------------
+    # GET /api/v2/data-importer/jobs/
+    # ------------------------------------------------------------------
+    def list(self, request):
+        qs = self.get_queryset().order_by("-created_at")[:30]
+        return Response(DataImportJobSerializer(qs, many=True).data)
+
+    # ------------------------------------------------------------------
     # GET /api/v2/data-importer/jobs/{id}/
     # ------------------------------------------------------------------
     def retrieve(self, request, pk=None):
@@ -102,6 +109,21 @@ class DataImporterViewSet(GenericViewSet):
         if job is None:
             return Response({"detail": "No encontrado."}, status=404)
         return Response(DataImportJobSerializer(job).data)
+
+    # ------------------------------------------------------------------
+    # DELETE /api/v2/data-importer/jobs/{id}/
+    # ------------------------------------------------------------------
+    def destroy(self, request, pk=None):
+        job = self._get_job(pk)
+        if job is None:
+            return Response({"detail": "No encontrado."}, status=404)
+        try:
+            if job.file_path:
+                job.file_path.delete(save=False)
+        except Exception:
+            logger.warning("No se pudo eliminar el archivo del job %s", pk)
+        job.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     # ------------------------------------------------------------------
     # PATCH /api/v2/data-importer/jobs/{id}/schema/
@@ -218,35 +240,20 @@ class DataImporterViewSet(GenericViewSet):
         if update_fields:
             job.save(update_fields=update_fields)
 
-        # Aplicar metadatos al dataset de GeoNode
-        if job.geonode_dataset_id:
-            _apply_metadata_to_dataset(job, d.get("name", ""), d.get("description", "") or d.get("layer_abstract", ""))
+        # Si el tablero ya fue construido, devolver el existente sin crear duplicado
+        if job.dashboard_site_id:
+            return Response({"site_id": job.dashboard_site_id, "job_id": job.id})
 
-        # Generar estilos con las preferencias del usuario
-        if job.geonode_dataset_id and job.style_specs and job.geo_strategy != "none":
-            try:
-                from geonode.layers.models import Dataset
-                from sigic_geonode.sigic_georeference.style_generator import (
-                    generate_and_register_styles_with_specs,
-                )
-                ds = Dataset.objects.filter(id=job.geonode_dataset_id).first()
-                if ds:
-                    generate_and_register_styles_with_specs(
-                        ds, job.style_specs,
-                        default_col=d.get("default_style_col") or None,
-                    )
-            except Exception:
-                logger.exception("Style generation failed for job %s (non-fatal)", pk)
+        # Limpiar error anterior de construcción de tablero si existe
+        if job.error_message.startswith("Error creando tablero:"):
+            job.error_message = ""
+            job.save(update_fields=["error_message"])
 
-        from .tablero_builder import build_tablero_from_job
-        try:
-            site_id = build_tablero_from_job(job)
-            job.dashboard_site_id = site_id
-            job.save(update_fields=["dashboard_site_id"])
-            return Response({"site_id": site_id})
-        except Exception as exc:
-            logger.exception("Error creando tablero para job %s", pk)
-            return Response({"detail": str(exc)}, status=500)
+        # Metadatos, estilos y construcción del tablero — todo en Celery
+        default_style_col = d.get("default_style_col") or None
+        from .tasks import build_tablero_task
+        build_tablero_task.delay(job.id, default_style_col)
+        return Response({"building": True, "job_id": job.id}, status=202)
 
     # ------------------------------------------------------------------
     # POST /api/v2/data-importer/jobs/{id}/finalize-layer/


### PR DESCRIPTION
## Resumen

**Construcción de tablero en Celery (async):**
- Nueva tarea `build_tablero_task`: ejecuta metadatos, estilos y construcción del tablero en segundo plano
- El endpoint `PATCH /{id}/finalize/` devuelve `202` inmediatamente y ya no bloquea el request HTTP
- Idempotente: si el tablero ya existe, devuelve el `site_id` sin crear duplicado

**API del importador:**
- `GET /api/v2/data-importer/jobs/` — lista los últimos 30 jobs del usuario autenticado
- `DELETE /api/v2/data-importer/jobs/{id}/` — elimina el job y su archivo asociado

**tablero_builder:**
- Usa conexión psycopg2 fresca por llamada (evita estado corrupto en conexión compartida)
- `geo_id_field` usa `ogc_fid` en lugar de `fid`
- Soporta hasta 20 columnas de estilo (era 10), priorizando numéricas sobre categóricas
- Indicadores categóricos usan tipo `donut` e infobox con campo `__count__`
- Soporta paletas inversas (`reverse`) al generar estilos e indicadores

**column_detector:**
- Añade `cvegeomun` al conjunto de claves municipales reconocidas
- Prefiere la clave compuesta de 5 dígitos (estado+municipio) sobre la clave municipal de 3 dígitos

## Plan de prueba

- [ ] Importar un dataset y finalizar — verificar que la respuesta es `202 { building: true }`
- [ ] Hacer polling a `GET /jobs/{id}/` y confirmar que `dashboard_site_id` se popula cuando termina
- [ ] Verificar `GET /jobs/` devuelve la lista de jobs recientes
- [ ] Verificar `DELETE /jobs/{id}/` elimina el job y el archivo
- [ ] Importar un CSV con columna `cvegeomun` y confirmar que se detecta como clave municipal